### PR TITLE
Add Apache GUI toggle and update port range

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ It will install WireGuard (kernel module and tools) on the server, configure it,
 
 12) Remove a port forwarding you previusly defined (requires a reboot of the host )
 13) add a limiter ( beta function , as of now it works only with 1 client at a time , and ipv4 only(ipv6 and subnet cant be limited for now))
-14) list all limiters (beta, will list only the upload part , and will most of the time list false warning idk why) 
+14) list all limiters (beta, will list only the upload part , and will most of the time list false warning idk why)
 15) remove ALL limiters (beta , once used check with ip a for remaining ifb device that should be there)
-16) Exit from the script
+16) Toggle Web GUI (install/remove Apache dashboard on port 65535)
+17) Exit from the script
 


### PR DESCRIPTION
## Summary
- adjust default port range to avoid using 65535
- provide `toggleGUI` helper to install/remove the web GUI
- update management menu with new option
- document web GUI toggle in README

## Testing
- `bash -n wg-setup.sh`
- `shellcheck wg-setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68834187c8b88327a2874b043e5fecd1