### PR TITLE
Add dynamic status polling in single PHP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ It will install WireGuard (kernel module and tools) on the server, configure it,
 16) Toggle Web GUI (install/remove Apache dashboard on port 65535)
 17) Exit from the script
 
+- The dashboard now refreshes client status dynamically without closing modals using AJAX polling in a single index.php.


### PR DESCRIPTION
## Summary
- inline helper functions in `index.php`
- remove separate `functions.php` and `status.php`
- serve table updates via `index.php?status=1`
- update JS polling and README note

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6888a2cfe5888327bcc4953a1297796e